### PR TITLE
Fix ROOT_URL fully

### DIFF
--- a/internal/globals.sh
+++ b/internal/globals.sh
@@ -162,8 +162,8 @@ function build_postindex {
 		ID="$(basename $(dirname "${P}"))"
 		TITLE="$(get_title "${P}")"
 		[[ "${PREFER_SHORT_POSTS}" == "yes" ]] &&
-			LINK="/p/${ID}.html" ||
-			LINK="/posts/$(echo "${TITLE}" | title_to_post_url)${TITLE_SEPARATOR_CHAR}${ID}.html"
+			LINK="${ROOT_URL}/p/${ID}.html" ||
+			LINK="${ROOT_URL}/posts/$(echo "${TITLE}" | title_to_post_url)${TITLE_SEPARATOR_CHAR}${ID}.html"
 		AUTHOR="$(get_author "${P}")"
 		DATE="$(get_date "${P}")"
 		DATE_PRETTY="$(ts_to_date "${DATE_FRMT}" "${DATE}")"
@@ -233,9 +233,9 @@ function build_tagindex {
 					TITLE="$(get_title "${HEADERS}")"
 					if [[ "${PREFER_SHORT_POSTS}" == "yes" ]]
 					then
-						LINK="/p/${ID}.html"
+						LINK="${ROOT_URL}/p/${ID}.html"
 					else
-						LINK="/posts/$(echo "${TITLE}" | title_to_post_url)${TITLE_SEPARATOR_CHAR}${ID}.html"
+						LINK="${ROOT_URL}/posts/$(echo "${TITLE}" | title_to_post_url)${TITLE_SEPARATOR_CHAR}${ID}.html"
 					fi
 					AUTHOR="$(get_author "${HEADERS}")"
 					echo "<li><a href='${LINK}'>${TITLE}</a> by ${AUTHOR} on ${DATE_PRETTY}</li>" | tee -a "${TMP_TAG_FILE}"
@@ -532,8 +532,8 @@ function post_markdown {
 	if (( "${#OPTS[@]}" > 0 )) && [[ " ${OPTS[@]} " =~ " for-preview " ]]
 	then
 		[[ "${PREFER_SHORT_POSTS}" == "yes" ]] && \
-			LINK="/p/${ID}.html" || \
-			LINK="/posts/$(get_title "${METADATA_DIR}/${ID}/headers" | title_to_post_url)${TITLE_SEPARATOR_CHAR}${ID}.html"
+			LINK="${ROOT_URL}/p/${ID}.html" || \
+			LINK="${ROOT_URL}/posts/$(get_title "${METADATA_DIR}/${ID}/headers" | title_to_post_url)${TITLE_SEPARATOR_CHAR}${ID}.html"
 		sed "s|\(<a href=['\"]\)\(#.*\)|\1${LINK}\2|" "${TMP1}" > "${TMP2}"
 	else
 		cat "${TMP1}" > "${TMP2}"


### PR DESCRIPTION
Should completely fix https://github.com/pastly/bm/issues/15.

I noticed how in some places the LINK variables had ROOT_URLs (https://github.com/pastly/bm/blob/master/internal/globals.sh#L83-L84), but a lot did not, so I just searched for all /posts or /p and prepended the ROOT_URL variable to match the way it was already being done.

This is live at https://aadibajpai.com/blog/ if you want to check once.

This also means there's no need to edit it directly in sed anymore.